### PR TITLE
Updated with new add_fleet_robots method

### DIFF
--- a/fleet_adapter_template/config.yaml
+++ b/fleet_adapter_template/config.yaml
@@ -3,6 +3,10 @@
 
 rmf_fleet:
   name: "DeliveryBot"
+  fleet_manager:
+    prefix: "http://127.0.0.1:8000"
+    user: "some_user"
+    password: "some_password"
   limits:
     linear: [0.4, 0.2] # velocity, acceleration
     angular: [0.3, 0.35] # velocity, acceleration
@@ -40,10 +44,7 @@ robots:
   # Configuration for first robot in this fleet
   deliverybot1:
     robot_config:
-      base_url: "http://192.168.0.1:8888" # API endpoint for the robot
-      user: "some_user"
-      password: "some_password"
-      # max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
+      max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
     rmf_config:
       robot_state_update_frequency: 0.5
       start:
@@ -58,10 +59,7 @@ robots:
   # Uncomment if more than one robot exists.
   # deliverybot2:
   #   robot_config:
-  #     base_url: "http://192.168.0.2:8888" # API endpoint for the robot
-  #     user: "some_user"
-  #     password: "some_password"
-  #     # max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
+  #     max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
   #   rmf_config:
   #     robot_state_update_frequency: 0.5
   #     start:

--- a/fleet_adapter_template/fleet_adapter_template/RobotClientAPI.py
+++ b/fleet_adapter_template/fleet_adapter_template/RobotClientAPI.py
@@ -46,7 +46,7 @@ class RobotAPI:
         # ------------------------ #
         return True
 
-    def position(self):
+    def position(self, robot_name: str):
         ''' Return [x, y, theta] expressed in the robot's coordinate frame or
             None if any errors are encountered'''
         # ------------------------ #
@@ -54,7 +54,7 @@ class RobotAPI:
         # ------------------------ #
         return None
 
-    def navigate(self, pose, map_name: str):
+    def navigate(self, robot_name: str, pose, map_name: str):
         ''' Request the robot to navigate to pose:[x,y,theta] where x, y and
             and theta are in the robot's coordinate convention. This function
             should return True if the robot has accepted the request,
@@ -64,7 +64,7 @@ class RobotAPI:
         # ------------------------ #
         return False
 
-    def start_process(self, process: str, map_name: str):
+    def start_process(self, robot_name: str, process: str, map_name: str):
         ''' Request the robot to begin a process. This is specific to the robot
             and the use case. For example, load/unload a cart for Deliverybot
             or begin cleaning a zone for a cleaning robot.
@@ -74,7 +74,7 @@ class RobotAPI:
         # ------------------------ #
         return False
 
-    def stop(self):
+    def stop(self, robot_name: str):
         ''' Command the robot to stop.
             Return True if robot has successfully stopped. Else False'''
         # ------------------------ #
@@ -82,7 +82,7 @@ class RobotAPI:
         # ------------------------ #
         return False
 
-    def navigation_remaining_duration(self):
+    def navigation_remaining_duration(self, robot_name: str):
         ''' Return the number of seconds remaining for the robot to reach its
             destination'''
         # ------------------------ #
@@ -90,7 +90,7 @@ class RobotAPI:
         # ------------------------ #
         return 0.0
 
-    def navigation_completed(self):
+    def navigation_completed(self, robot_name: str):
         ''' Return True if the robot has successfully completed its previous
             navigation request. Else False.'''
         # ------------------------ #
@@ -98,7 +98,7 @@ class RobotAPI:
         # ------------------------ #
         return False
 
-    def process_completed(self):
+    def process_completed(self, robot_name: str):
         ''' Return True if the robot has successfully completed its previous
             process request. Else False.'''
         # ------------------------ #
@@ -106,7 +106,7 @@ class RobotAPI:
         # ------------------------ #
         return False
 
-    def battery_soc(self):
+    def battery_soc(self, robot_name: str):
         ''' Return the state of charge of the robot as a value between 0.0
             and 1.0. Else return None if any errors are encountered'''
         # ------------------------ #

--- a/fleet_adapter_template/fleet_adapter_template/RobotCommandHandle.py
+++ b/fleet_adapter_template/fleet_adapter_template/RobotCommandHandle.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rclpy.duration import Duration
 
 import rmf_adapter as adpt
 import rmf_adapter.plan as plan
@@ -29,8 +30,6 @@ import time
 
 from datetime import timedelta
 
-from .RobotClientAPI import RobotAPI
-
 
 # States for RobotCommandHandle's state machine used when guiding robot along
 # a new path
@@ -43,27 +42,28 @@ class RobotState(enum.IntEnum):
 class RobotCommandHandle(adpt.RobotCommandHandle):
     def __init__(self,
                  name,
+                 fleet_name,
                  config,
                  node,
                  graph,
                  vehicle_traits,
                  transforms,
                  map_name,
-                 initial_waypoint,
-                 initial_orientation,
+                 start,
+                 position,
                  charger_waypoint,
                  update_frequency,
-                 adapter):
+                 adapter,
+                 api):
         adpt.RobotCommandHandle.__init__(self)
         self.name = name
+        self.fleet_name = fleet_name
         self.config = config
         self.node = node
         self.graph = graph
         self.vehicle_traits = vehicle_traits
         self.transforms = transforms
         self.map_name = map_name
-        self.initial_waypoint = initial_waypoint
-        self.initial_orientation = initial_orientation
         # Get the index of the charger waypoint
         waypoint = self.graph.find_waypoint(charger_waypoint)
         assert waypoint, f"Charger waypoint {charger_waypoint} \
@@ -73,8 +73,8 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         self.update_frequency = update_frequency
         self.update_handle = None  # RobotUpdateHandle
         self.battery_soc = 1.0
-        self.api = None
-        self.position = []  # (x,y,theta) in RMF coordinates (meters, radians)
+        self.api = api
+        self.position = position  # (x,y,theta) in RMF coordinates (meters, radians)
         self.initialized = False
         self.state = RobotState.IDLE
         self.dock_name = ""
@@ -105,48 +105,9 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         self._dock_thread = None
         self._quit_dock_event = threading.Event()
 
-        # Establish connection with the robot
-        self.api = RobotAPI(
-            self.config['base_url'],
-            self.config['user'],
-            self.config['password'])
-        assert self.api.connected, "Unable to connect to Robot API server"
-
-        self.position = self.get_position()  # RMF coordinates
-        assert len(
-            self.position) > 2, "Unable to get current location of the robot"
         self.node.get_logger().info(
             f"The robot is starting at: [{self.position[0]:.2f}, "
             f"{self.position[1]:.2f}, {self.position[2]:.2f}]")
-        # Obtain StartSet for the robot
-        self.starts = []
-        time_now = self.adapter.now()
-        if (self.initial_waypoint is not None) and\
-                (self.initial_orientation is not None):
-            self.node.get_logger().info(
-                f"Using provided initial waypoint [{self.initial_waypoint}] "
-                f"and orientation [{self.initial_orientation:.2f}] to "
-                f"initialize starts for robot [{self.name}]")
-            # Get the waypoint index for initial_waypoint
-            initial_waypoint_index = self.graph.find_waypoint(
-                self.initial_waypoint).index
-            self.starts = [plan.Start(time_now,
-                                      initial_waypoint_index,
-                                      self.initial_orientation)]
-        else:
-            self.node.get_logger().info(
-                f"Running compute_plan_starts for robot:{self.name}")
-            self.starts = plan.compute_plan_starts(
-                self.graph,
-                self.map_name,
-                self.position,
-                time_now)
-
-        if self.starts is None or len(self.starts) == 0:
-            self.node.get_logger().error(
-                f"Unable to determine StartSet for {self.name}")
-            return
-        start = self.starts[0]
 
         # Update tracking variables
         if start.lane is not None:  # If the robot is on a lane
@@ -163,6 +124,12 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
 
         self.initialized = True
 
+    def sleep_for(self, seconds):
+        goal_time =\
+          self.node.get_clock().now() + Duration(nanoseconds=1e9*seconds)
+        while (self.node.get_clock().now() <= goal_time):
+            time.sleep(0.001)
+
     def clear(self):
         with self._lock:
             self.requested_waypoints = []
@@ -176,9 +143,9 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         # Stop the robot. Tracking variables should remain unchanged.
         while True:
             self.node.get_logger().info("Requesting robot to stop...")
-            if self.api.stop():
+            if self.api.stop(self.name):
                 break
-            time.sleep(1.0)
+            self.sleep_for(0.1)
         if self._follow_path_thread is not None:
             self._quit_path_event.set()
             if self._follow_path_thread.is_alive():
@@ -229,7 +196,9 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                     # IMPLEMENT YOUR CODE HERE #
                     # Ensure x, y, theta are in units that api.navigate() #
                     # ------------------------ #
-                    response = self.api.navigate([x, y, theta], self.map_name)
+                    response = self.api.navigate(self.name,
+                                                 [x, y, theta],
+                                                 self.map_name)
 
                     if response:
                         self.remaining_waypoints = self.remaining_waypoints[1:]
@@ -239,10 +208,10 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                             f"Robot {self.name} failed to navigate to "
                             f"[{x:.0f}, {y:.0f}, {theta:.0f}] coordinates. "
                             f"Retrying...")
-                        time.sleep(1.0)
+                        self.sleep_for(0.1)
 
                 elif self.state == RobotState.WAITING:
-                    time.sleep(1.0)
+                    self.sleep_for(0.1)
                     time_now = self.adapter.now()
                     with self._lock:
                         if self.target_waypoint is not None:
@@ -258,10 +227,10 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                                         self.path_index, timedelta(seconds=0.0))
 
                 elif self.state == RobotState.MOVING:
-                    time.sleep(1.0)
+                    self.sleep_for(0.1)
                     # Check if we have reached the target
                     with self._lock:
-                        if (self.api.navigation_completed()):
+                        if (self.api.navigation_completed(self.name)):
                             self.node.get_logger().info(
                                 f"Robot [{self.name}] has reached its target "
                                 f"waypoint")
@@ -299,7 +268,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                         # remaining travel duration, replace the API call
                         # below with an estimation
                         # ------------------------ #
-                        duration = self.api.navigation_remaining_duration()
+                        duration = self.api.navigation_remaining_duration(self.name)
                         if self.path_index is not None:
                             self.next_arrival_estimator(
                                 self.path_index, timedelta(seconds=duration))
@@ -341,23 +310,23 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
             # Request the robot to start the relevant process
             self.node.get_logger().info(
                 f"Requesting robot {self.name} to dock at {self.dock_name}")
-            self.api.start_process(self.dock_name, self.map_name)
+            self.api.start_process(self.name, self.dock_name, self.map_name)
 
             with self._lock:
                 self.on_waypoint = None
                 self.on_lane = None
-            time.sleep(1.0)
+            self.sleep_for(0.1)
             # ------------------------ #
             # IMPLEMENT YOUR CODE HERE #
             # With whatever logic you need for docking #
             # ------------------------ #
-            while (not self.api.docking_completed()):
+            while (not self.api.docking_completed(self.name)):
                 # Check if we need to abort
                 if self._quit_dock_event.is_set():
                     self.node.get_logger().info("Aborting docking")
                     return
                 self.node.get_logger().info("Robot is docking...")
-                time.sleep(1.0)
+                self.sleep_for(0.1)
 
             with self._lock:
                 self.on_waypoint = self.dock_waypoint_index
@@ -371,7 +340,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
     def get_position(self):
         ''' This helper function returns the live position of the robot in the
         RMF coordinate frame'''
-        position = self.api.position()
+        position = self.api.position(self.name)
         if position is not None:
             x, y = self.transforms['robot_to_rmf'].transform(
                 [position[0], position[1]])
@@ -394,7 +363,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
             return self.position
 
     def get_battery_soc(self):
-        battery_soc = self.api.battery_soc()
+        battery_soc = self.api.battery_soc(self.name)
         if battery_soc is not None:
             return battery_soc
         else:
@@ -448,7 +417,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                 self.update_handle.update_off_grid_position(
                     self.position, self.dock_waypoint_index)
             # if robot is merging into a waypoint
-            elif (self.target_waypoint is not None and \
+            elif (self.target_waypoint is not None and
                 self.target_waypoint.graph_index is not None):
                 self.update_handle.update_off_grid_position(
                     self.position, self.target_waypoint.graph_index)

--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -17,6 +17,7 @@ import argparse
 import yaml
 import nudged
 import time
+import threading
 
 import rclpy
 import rclpy.node
@@ -34,6 +35,7 @@ from rmf_task_msgs.msg import TaskProfile, TaskType
 from functools import partial
 
 from .RobotCommandHandle import RobotCommandHandle
+from .RobotClientAPI import RobotAPI
 
 # ------------------------------------------------------------------------------
 # Helper functions
@@ -160,44 +162,108 @@ def initialize_fleet(config_yaml, nav_graph_path, node, use_sim_time):
         """Insert a RobotUpdateHandle."""
         cmd_handle.update_handle = update_handle
 
+    # Initialize robot API for this fleet
+    api = RobotAPI(
+        fleet_config['fleet_manager']['prefix'],
+        fleet_config['fleet_manager']['user'],
+        fleet_config['fleet_manager']['password'])
+
     # Initialize robots for this fleet
-    robots = {}
-    for robot_name, robot_config in config_yaml['robots'].items():
-        node.get_logger().info(f"Initializing robot:{robot_name}")
-        rmf_config = robot_config['rmf_config']
-        robot_config = robot_config['robot_config']
-        initial_waypoint = rmf_config['start']['waypoint']
-        initial_orientation = rmf_config['start']['orientation']
-        robot = RobotCommandHandle(
-            name=robot_name,
-            config=robot_config,
-            node=node,
-            graph=nav_graph,
-            vehicle_traits=vehicle_traits,
-            transforms=transforms,
-            map_name=rmf_config['start']['map_name'],
-            initial_waypoint=initial_waypoint,
-            initial_orientation=initial_orientation,
-            charger_waypoint=rmf_config['charger']['waypoint'],
-            update_frequency=rmf_config.get('robot_state_update_frequency', 1),
-            adapter=adapter)
 
-        if robot.initialized:
-            robots[robot_name] = robot
-            # Add robot to fleet
-            fleet_handle.add_robot(robot,
-                                   robot_name,
-                                   profile,
-                                   robot.starts,
-                                   partial(_updater_inserter, robot))
-            node.get_logger().info(
-                f"Successfully added new robot:{robot_name}")
+    missing_robots = config_yaml['robots']
 
-        else:
-            node.get_logger().error(
-                f"Failed to initialize robot:{robot_name}")
+    def _add_fleet_robots():
+        robots = {}
+        while len(missing_robots) > 0:
+            time.sleep(0.2)
+            for robot_name in list(missing_robots.keys()):
+                node.get_logger().debug(f"Connecting to robot: {robot_name}")
+                position = api.position(robot_name)
+                if position is None:
+                    continue
+                if len(position) > 2:
+                    node.get_logger().info(f"Initializing robot: {robot_name}")
+                    robots_config = config_yaml['robots'][robot_name]
+                    rmf_config = robots_config['rmf_config']
+                    robot_config = robots_config['robot_config']
+                    initial_waypoint = rmf_config['start']['waypoint']
+                    initial_orientation = rmf_config['start']['orientation']
 
-    return adapter, fleet_handle, robots
+                    starts = []
+                    time_now = adapter.now()
+
+                    if (initial_waypoint is not None) and\
+                            (initial_orientation is not None):
+                        node.get_logger().info(
+                            f"Using provided initial waypoint "
+                            "[{initial_waypoint}] "
+                            f"and orientation [{initial_orientation:.2f}] to "
+                            f"initialize starts for robot [{robot_name}]")
+                        # Get the waypoint index for initial_waypoint
+                        initial_waypoint_index = nav_graph.find_waypoint(
+                            initial_waypoint).index
+                        starts = [plan.Start(time_now,
+                                             initial_waypoint_index,
+                                             initial_orientation)]
+                    else:
+                        node.get_logger().info(
+                            f"Running compute_plan_starts for robot: "
+                            "{robot_name}")
+                        starts = plan.compute_plan_starts(
+                            nav_graph,
+                            rmf_config['start']['map_name'],
+                            position,
+                            time_now)
+
+                    if starts is None or len(starts) == 0:
+                        node.get_logger().error(
+                            f"Unable to determine StartSet for {robot_name}")
+                        continue
+
+                    robot = RobotCommandHandle(
+                        name=robot_name,
+                        fleet_name=fleet_name,
+                        config=robot_config,
+                        node=node,
+                        graph=nav_graph,
+                        vehicle_traits=vehicle_traits,
+                        transforms=transforms,
+                        map_name=rmf_config['start']['map_name'],
+                        start=starts[0],
+                        position=position,
+                        charger_waypoint=rmf_config['charger']['waypoint'],
+                        update_frequency=rmf_config.get(
+                            'robot_state_update_frequency', 1),
+                        adapter=adapter,
+                        api=api)
+
+                    if robot.initialized:
+                        robots[robot_name] = robot
+                        # Add robot to fleet
+                        fleet_handle.add_robot(robot,
+                                               robot_name,
+                                               profile,
+                                               [starts[0]],
+                                               partial(_updater_inserter,
+                                                       robot))
+                        node.get_logger().info(
+                            f"Successfully added new robot: {robot_name}")
+
+                    else:
+                        node.get_logger().error(
+                            f"Failed to initialize robot: {robot_name}")
+
+                    del missing_robots[robot_name]
+
+                else:
+                    pass
+                    node.get_logger().debug(
+                        f"{robot_name} not found, trying again...")
+        return
+
+    add_robots = threading.Thread(target=_add_fleet_robots, args=())
+    add_robots.start()
+    return adapter
 
 
 # ------------------------------------------------------------------------------
@@ -229,14 +295,15 @@ def main(argv=sys.argv):
         config_yaml = yaml.safe_load(f)
 
     # ROS 2 node for the command handle
-    node = rclpy.node.Node('robot_command_handle')
+    fleet_name = config_yaml['rmf_fleet']['name']
+    node = rclpy.node.Node(f'{fleet_name}_command_handle')
 
     # Enable sim time for testing offline
     if args.use_sim_time:
         param = Parameter("use_sim_time", Parameter.Type.BOOL, True)
         node.set_parameters([param])
 
-    adapter, fleet_handle, robots = initialize_fleet(
+    adapter = initialize_fleet(
         config_yaml,
         nav_graph_path,
         node,


### PR DESCRIPTION
Updated this template according to changes in this PR open-rmf/rmf_demos#109

Mainly changed the way robots are added to the fleet. There is now one `RobotClientAPI` per fleet that is shared between multiple `RobotCommandHandle` (one per robot). Robots are only added to the fleet after the API connects successfully.

Also slightly edited `config.yaml`: since the API is fleet-specific, the prefix, username and password used to connect the API is moved to the `rmf_fleet` section under `fleet_manager`.