### PR TITLE
Updated input args to read websocket server uri and publish task summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ The `config.yaml` file contains important parameters for setting up the fleet ad
 
 Run the command below while passing the paths to the configuration file and navigation graph that this fleet operates on.
 
+The websocket server URI should also be passed as a parameter in this command inorder to publish task statuses to the rest of the RMF entities.
+
 ```bash
+#minimal required parameters
 ros2 run fleet_adapter_template fleet_adapter -c CONFIG_FILE -n NAV_GRAPH
 
+#Usage with the websocket uri
+ros2 run fleet_adapter_template fleet_adapter -c CONFIG_FILE -n NAV_GRAPH -s SERVER_URI
+
+#e.g.
+ros2 run fleet_adapter_template fleet_adapter -c CONFIG_FILE -n NAV_GRAPH -s ws://localhost:7878
 ```

--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -42,7 +42,7 @@ from .RobotClientAPI import RobotAPI
 # ------------------------------------------------------------------------------
 
 
-def initialize_fleet(config_yaml, nav_graph_path, node, use_sim_time):
+def initialize_fleet(config_yaml, nav_graph_path, node, use_sim_time, server_uri):
     # Profile and traits
     fleet_config = config_yaml['rmf_fleet']
     profile = traits.Profile(geometry.make_final_convex_circle(
@@ -91,7 +91,7 @@ def initialize_fleet(config_yaml, nav_graph_path, node, use_sim_time):
     adapter.start()
     time.sleep(1.0)
 
-    fleet_handle = adapter.add_fleet(fleet_name, vehicle_traits, nav_graph)
+    fleet_handle = adapter.add_fleet(fleet_name, vehicle_traits, nav_graph, server_uri)
 
     if not fleet_config['publish_fleet_state']:
         fleet_handle.fleet_state_publish_period(None)
@@ -282,6 +282,8 @@ def main(argv=sys.argv):
                         help="Path to the config.yaml file")
     parser.add_argument("-n", "--nav_graph", type=str, required=True,
                         help="Path to the nav_graph for this fleet adapter")
+    parser.add_argument("-s", "--server_uri", type=str, required=False, default="",
+                    help="URI of the api server to transmit state and task information.")
     parser.add_argument("--use_sim_time", action="store_true",
                         help='Use sim time, default: false')
     args = parser.parse_args(args_without_ros[1:])
@@ -303,11 +305,17 @@ def main(argv=sys.argv):
         param = Parameter("use_sim_time", Parameter.Type.BOOL, True)
         node.set_parameters([param])
 
+     if args.server_uri == "":
+        server_uri = None
+    else:
+        server_uri = args.server_uri
+
     adapter = initialize_fleet(
         config_yaml,
         nav_graph_path,
         node,
-        args.use_sim_time)
+        args.use_sim_time,
+        server_uri)
 
     # Create executor for the command handle node
     rclpy_executor = rclpy.executors.SingleThreadedExecutor()


### PR DESCRIPTION
## Bug fix

### Fixed bug
The current fleet adapter template doesn't have a provision to pass the websocket server uri that is required for task summaries.
System integrators that use this template won't be able to monitor task progress via the RMF Panel or any other means that rely on websockets. This is because the `add_fleet` function of the `Adapter` class assigns a `nullptr` to the `server_uri` parameter by default.

### Fix applied
A new optional parameter `-s` or `--server_uri` has been added to `fleet_adapter.py`. This parameter is then passed to `adapter.add_fleet()` via the `initialize_fleet()` function.

The README has also been updated to reflect this change.

I had earlier used a different description for the parameter but later changed it to match the implementation in ecobot's fleet adapter here: https://github.com/open-rmf/fleet_adapter_ecobot/blob/b24def9d1b778819f82c74df20820e5d1ba5b47e/fleet_adapter_ecobot/fleet_adapter_ecobot.py#L288


