### PR TITLE
Fixed AttributeError

### DIFF
--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -141,7 +141,7 @@ def main(argv=sys.argv):
 
             # Update all the robots in parallel using a thread pool
             update_jobs = []
-            for robot in robots.keys():
+            for robot in robots.values():
                 update_jobs.append(update_robot(robot))
 
             asyncio.get_event_loop().run_until_complete(


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix


Fix for `AttributeError: 'str' object has no attribute 'api'`

This seems to be already fixed in [rmf_demos_fleet_adapter](https://github.com/open-rmf/rmf_demos/blob/main/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py#L133).