### PR TITLE
Add fleet config after adding robot transforms

### DIFF
--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -112,12 +112,13 @@ def main(argv=sys.argv):
         server_uri = args.server_uri
 
     fleet_config.server_uri = server_uri
-    fleet_handle = adapter.add_easy_fleet(fleet_config)
 
     # Configure the transforms between robot and RMF frames
     for level, coords in config_yaml['reference_coordinates'].items():
         tf = compute_transforms(level, coords, node)
         fleet_config.add_robot_coordinates_transformation(level, tf)
+
+    fleet_handle = adapter.add_easy_fleet(fleet_config)
 
     # Initialize robot API for this fleet
     fleet_mgr_yaml = config_yaml['fleet_manager']


### PR DESCRIPTION
This PR fixes a previous bug where the configured RMF to robot (and vice versa) coordinate transformation is only added to the FleetConfiguration after the EasyFullControl robot handle is added and created. By moving the `add_easy_fleet` call down, we can ensure that these transformations are stored in the fleet and used properly.