### PR TITLE
Fix/bug 36

### DIFF
--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -128,7 +128,7 @@ def main(argv=sys.argv):
     for robot_name in fleet_config.known_robots:
         robot_config = fleet_config.get_known_robot_configuration(robot_name)
         robots[robot_name] = RobotAdapter(
-            robot_name, robot_config, node, api, fleet_handle
+            robot_name, robot_config, node, api, fleet_handle, fleet_config
         )
 
     update_period = 1.0/config_yaml['rmf_fleet'].get(
@@ -176,7 +176,8 @@ class RobotAdapter:
         configuration,
         node,
         api: RobotAPI,
-        fleet_handle
+        fleet_handle,
+        fleet_config
     ):
         self.name = name
         self.execution = None
@@ -185,6 +186,8 @@ class RobotAdapter:
         self.node = node
         self.api = api
         self.fleet_handle = fleet_handle
+        self.fleet_config = fleet_config
+        self.rmf_to_robot_transforms = self.fleet_config.transformations_to_robot_coordinates
 
     def update(self, state):
         activity_identifier = None

--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -218,9 +218,13 @@ class RobotAdapter:
             f'on map [{destination.map}]'
         )
 
+        self.node.get_logger().info(f'Converting RMF to Robot coordinates...')
+        rmf_pos = destination.position
+        robot_pos = self.rmf_to_robot_transforms[destination.map].apply(rmf_pos)
+
         self.api.navigate(
             self.name,
-            destination.position,
+            robot_pos,
             destination.map,
             destination.speed_limit
         )
@@ -259,9 +263,13 @@ def update_robot(robot: RobotAdapter):
     if data is None:
         return
 
+    robot.node.get_logger().info(f'Converting Robot to RMF coordinates...')
+    robot_pos = data.position
+    rmf_pos = robot.rmf_to_robot_transforms[data.map].apply_inverse(robot_pos)
+
     state = rmf_easy.RobotState(
         data.map,
-        data.position,
+        rmf_pos,
         data.battery_soc
     )
 

--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -261,6 +261,8 @@ def parallel(f):
 def update_robot(robot: RobotAdapter):
     data = robot.api.get_data(robot.name)
     if data is None:
+        robot.node.get_logger().warn(f"Unable to retrieve data of {robot.name}. "
+                                     "Skipping update...")
         return
 
     robot.node.get_logger().info(f'Converting Robot to RMF coordinates...')

--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -218,13 +218,9 @@ class RobotAdapter:
             f'on map [{destination.map}]'
         )
 
-        self.node.get_logger().info(f'Converting RMF to Robot coordinates...')
-        rmf_pos = destination.position
-        robot_pos = self.rmf_to_robot_transforms[destination.map].apply(rmf_pos)
-
         self.api.navigate(
             self.name,
-            robot_pos,
+            destination.position,
             destination.map,
             destination.speed_limit
         )


### PR DESCRIPTION
## **Bug Fix** :bug: :fist_oncoming: 

### **Fixed Bug**

This Pull Request address #36 and ensures that transform values for user-inputted map coordinates in their robot's `config.yaml` is being used properly in a fleet adapter's `update` and `navigate` function.

### Fix Applied :star: 

Edits made are summarised as follows:
- `fleet_config` is included as new class attribute for `RobotAdapter` class object.
- `update` function is elaborated to use Transform matrix generated from `config.yaml` to convert Robot to RMF coordinates.
- `navigate` function is elaborated to use Transform matrix generated from `config.yaml` to convert RMF to Robot coordinates before calling `RobotClientAPI`'s `navigate`.

## **New Feature Implementation** :bookmark_tabs: 

### **Implemented Feature(s)**

Please refer to the Fix Applied section above. 

### **Implementation Description**

Through the edits introduced, a generic fleet adapter will be able to use the generated Transformation Matrix (that was created via `nudged` using the reference coordinates in a robot's `config.yaml`) to update robot status and issue navigate as per RMF behaviour.

### **GenAI Use**
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR. 
- [x] I did not use GenAI

Generated-by: [Gary Bey](https://github.com/cardboardcode)

## **Remarks** :speech_balloon: 

@arjo129 Thank you for merging in the previous pull requests concerning the long-standing delay. May I request yours or your team's help to review this pull request?
