### PR TITLE
Fixes #39

### DIFF
--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -192,7 +192,7 @@ class RobotAdapter:
         if execution:
             if self.api.is_command_completed():
                 execution.finished()
-                execution = None
+                self.execution = None
             else:
                 activity_identifier = execution.identifier
 

--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -224,9 +224,10 @@ class RobotAdapter:
         )
 
     def stop(self, activity):
-        if self.execution is not None:
-            if self.execution.identifier.is_same(activity):
-                self.execution = None
+        execution = self.execution
+        if execution is not None:
+            if execution.identifier.is_same(activity):
+                execution = None
                 self.api.stop(self.name)
 
     def execute_action(self, category: str, description: dict, execution):

--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -188,12 +188,13 @@ class RobotAdapter:
 
     def update(self, state):
         activity_identifier = None
-        if self.execution:
+        execution = self.execution
+        if execution:  # use execution here instead of self.execution, otherwise the race condition might still happen
             if self.api.is_command_completed():
-                self.execution.finished()
-                self.execution = None
+                execution.finished()
+                execution = None
             else:
-                activity_identifier = self.execution.identifier
+                activity_identifier = execution.identifier
 
         self.update_handle.update(state, activity_identifier)
 

--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -189,7 +189,7 @@ class RobotAdapter:
     def update(self, state):
         activity_identifier = None
         execution = self.execution
-        if execution:  # use execution here instead of self.execution, otherwise the race condition might still happen
+        if execution:
             if self.api.is_command_completed():
                 execution.finished()
                 execution = None

--- a/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
+++ b/fleet_adapter_template/fleet_adapter_template/fleet_adapter.py
@@ -227,7 +227,7 @@ class RobotAdapter:
         execution = self.execution
         if execution is not None:
             if execution.identifier.is_same(activity):
-                execution = None
+                self.execution = None
                 self.api.stop(self.name)
 
     def execute_action(self, category: str, description: dict, execution):


### PR DESCRIPTION
## **Bug fix** :bug: 

### **Fixed bug** :bug: :wave: 

The bug in question that is fixed by this Pull Request (PR) is #39. Please see issue thread for further details on the bug.

### **Fix applied**

The fix introduced in this PR reduces the number of times `self.execution` is used in `RobotAdapter`'s `update` and `stop` function, allowing safeguards against `self.execution` being **NoneType** object to work in the sequential running of both functions.

## **New feature implementation**
### **Implemented feature**

NA

### **Implementation description**

NA

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [x ] I did not use GenAI

Generated-by: Gary Bey 
