### PR TITLE
Added launch module + other code clean-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ ros2 run fleet_adapter_template fleet_adapter -c CONFIG_FILE -n NAV_GRAPH
 #Usage with the websocket uri
 ros2 run fleet_adapter_template fleet_adapter -c CONFIG_FILE -n NAV_GRAPH -s SERVER_URI
 
+#Usage with ros2 launch
+ros2 launch fleet_adapter_template fleet_adapter.launch.xml -c CONFIG_FILE -n NAV_GRAPH -s SERVER_URI
+
 #e.g.
 ros2 run fleet_adapter_template fleet_adapter -c CONFIG_FILE -n NAV_GRAPH -s ws://localhost:7878
+
+#e.g.
+ros2 launch fleet_adapter_template fleet_adapter.launch.xml -c CONFIG_FILE -n NAV_GRAPH -s ws://localhost:7878
 ```

--- a/fleet_adapter_template/launch/fleet_adapter.launch.xml
+++ b/fleet_adapter_template/launch/fleet_adapter.launch.xml
@@ -2,17 +2,18 @@
 
 <launch>
   <!-- Fleet Adapter Parameters -->
-  <arg name="config_file" default=""/>
-  <arg name="nav_graph_file" default=""/>
-  <arg name="server_uri" default=""/>
-  <arg name="use_sim_time" default="true"/>
+  <arg name="use_sim_time" default="true" description="Use the /clock topic for time to sync with simulation"/>
+  <arg name="config_file" description="The config file that provides important parameters for setting up the adapter"/>
+  <arg name="nav_graph_file" description="The graph that this fleet should use for navigation"/>
+  <arg name="server_uri" default="" description="The URI of the api server to transmit state and task information."/>
+  <arg name="output" default="both"/>
 
   <!-- Fleet Adapter Template  -->
   <group if="$(var use_sim_time)">
     <node pkg="fleet_adapter_template"
           exec="fleet_adapter"
           args="-c $(var config_file) -n $(var nav_graph_file) -sim"
-          output="both">
+          output="$(var output)">
 
       <param name="server_uri" value="$(var server_uri)"/>
     </node>
@@ -22,7 +23,7 @@
     <node pkg="fleet_adapter_template"
           exec="fleet_adapter"
           args="-c $(var config_file) -n $(var nav_graph_file)"
-          output="both">
+          output="$(var output)">
 
       <param name="server_uri" value="$(var server_uri)"/>
     </node>

--- a/fleet_adapter_template/launch/fleet_adapter.launch.xml
+++ b/fleet_adapter_template/launch/fleet_adapter.launch.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' ?>
+
+<launch>
+  <!-- Fleet Adapter Parameters -->
+  <arg name="config_file" default=""/>
+  <arg name="nav_graph_file" default=""/>
+  <arg name="server_uri" default=""/>
+  <arg name="use_sim_time" default="true"/>
+
+  <!-- Fleet Adapter Template  -->
+  <group if="$(var use_sim_time)">
+    <node pkg="fleet_adapter_template"
+          exec="fleet_adapter"
+          args="-c $(var config_file) -n $(var nav_graph_file) -sim"
+          output="both">
+
+      <param name="server_uri" value="$(var server_uri)"/>
+    </node>
+  </group>
+
+  <group unless="$(var use_sim_time)">
+    <node pkg="fleet_adapter_template"
+          exec="fleet_adapter"
+          args="-c $(var config_file) -n $(var nav_graph_file)"
+          output="both">
+
+      <param name="server_uri" value="$(var server_uri)"/>
+    </node>
+  </group>
+
+</launch>

--- a/fleet_adapter_template/setup.cfg
+++ b/fleet_adapter_template/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/fleet_adapter_template
+script_dir=$base/lib/fleet_adapter_template
 [install]
-install-scripts=$base/lib/fleet_adapter_template
+install_scripts=$base/lib/fleet_adapter_template

--- a/fleet_adapter_template/setup.py
+++ b/fleet_adapter_template/setup.py
@@ -1,3 +1,5 @@
+import os
+from glob import glob
 from setuptools import setup
 
 package_name = 'fleet_adapter_template'
@@ -11,6 +13,7 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name,['config.yaml']),
+        (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
 
     ],
     install_requires=['setuptools'],


### PR DESCRIPTION
## **New Feature Implementation** :star2: :hammer: 

### **Implemented Feature(s)** :books: 

- Added and verified use of `fleet_adapter.launch.xml`.
- Updated variables in `setup.cfg` to avoid deprecation warnings and reduce build log verbosity.

### Implementation Description :book: 

Similar to how `free_fleet` has implemented its own launch module, the added launch module should allow for higher modularity with the following common 3rd-party connectivity interfaces:

- MQTT Client which may run separate from `fleet_adapter.py`.
- Other ROS 2 modules that provides external monitoring of `fleet_adapter.py` or for higher code modularity.

### GenAI Use :warning: 
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by: `Not Applicable`

## **Remarks** :speech_balloon: 

Been writing another custom RMF Fleet Adapter recently and found myself adding this feature repeatedly.
